### PR TITLE
ci: update tsm to v2.2.2 to fix nodejs 18.6+ issue, reset node v to 18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.5
+          node-version: 18
 
       - name: Install deps
         run: yarn install
@@ -55,7 +55,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.5
+          node-version: 18
 
       - name: Install deps
         run: yarn install

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,5 +1,5 @@
 name: integration-test
-on: [push, pull_request]
+on: [push]
 jobs:
   action-test:
     strategy:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Bun
         uses: ./
+        with:
+          token: ${{ github.token }}
 
       - name: Run script
         run: bun -v

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   "devDependencies": {
     "@types/semver": "^7.3.10",
     "@vercel/ncc": "^0.34.0",
-    "c8": "^7.11.3",
+    "c8": "^7.12.0",
     "loadr": "^0.1.1",
     "prettier": "^2.7.1",
     "tempy": "^3.0.0",
-    "tsm": "^2.2.1",
+    "tsm": "^2.2.2",
     "typescript": "^4.7.4",
     "uvu": "^0.5.6"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -277,10 +277,10 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-c8@^7.11.3:
-  version "7.11.3"
-  resolved "https://registry.yarnpkg.com/c8/-/c8-7.11.3.tgz#88c8459c1952ed4f701b619493c9ae732b057163"
-  integrity sha512-6YBmsaNmqRm9OS3ZbIiL2EZgi1+Xc4O24jL3vMYGE6idixYuGdy76rIfIdltSKDj9DpLNrcXSonUTR1miBD0wA==
+c8@^7.12.0:
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/c8/-/c8-7.12.0.tgz#402db1c1af4af5249153535d1c84ad70c5c96b14"
+  integrity sha512-CtgQrHOkyxr5koX1wEUmN/5cfDa2ckbHRA4Gy5LAL0zaCFtVWJS5++n+w4/sr2GWGerBxgTjpKeDclk/Qk6W/A==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
     "@istanbuljs/schema" "^0.1.3"
@@ -898,10 +898,10 @@ tslib@^2.2.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-tsm@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/tsm/-/tsm-2.2.1.tgz#3e78e86a03b2f569c20cff4a9f66c4ec8fce65fc"
-  integrity sha512-qvJB0baPnxQJolZru11mRgGTdNlx17WqgJnle7eht3Vhb+VUR4/zFA5hFl6NqRe7m8BD9w/6yu0B2XciRrdoJA==
+tsm@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/tsm/-/tsm-2.2.2.tgz#0edacd62bbe53a87e8fc9c260ab65a7dbac5de06"
+  integrity sha512-bXkt675NbbqfwRHSSn8kSNEEHvoIUFDM9G6tUENkjEKpAEbrEzieO3PxUiRJylMw8fEGpcf5lSjadzzz12pc2A==
   dependencies:
     esbuild "^0.14.0"
 


### PR DESCRIPTION
https://github.com/lukeed/tsm/pull/37

<!-- 
Add a link to issue, another PR, discussion with which this PR is associated.
Select the most suitable relation type: fixes / closes / relates
-->
Fixes [#id]
<!-- Maybe you'd like to discuss this at first? Your may always create a new issue / discussion topic -->

## Changes
<!-- What exactly you have changed, and how it works now -->

- [ ] New code is covered by tests
- [ ] All the changes are mentioned in docs (readme.md)
